### PR TITLE
Update published label prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The current set of feature sources are the following:
 
 The published node labels encode a few pieces of information:
 
-- A "namespace" (e.g. `node.alpha.intel.com/nfd`).
+- A "namespace" (e.g. `node.alpha.kubernetes-incubator.io/nfd`).
 - The version of this discovery code that wrote the label, according to
   `git describe --tags --dirty --always`.
 - The source for each label (e.g. `cpuid`).
@@ -71,10 +71,10 @@ the only label value published for features is the string `"true"`._
 
 ```json
 {
-  "node.alpha.intel.com/node-feature-discovery.version": "v0.1.0",
-  "node.alpha.intel.com/nfd-cpuid-<feature-name>": "true",
-  "node.alpha.intel.com/nfd-rdt-<feature-name>": "true",
-  "node.alpha.intel.com/nfd-pstate-<feature-name>": "true"
+  "node.alpha.kubernetes-incubator.io/node-feature-discovery.version": "v0.1.0",
+  "node.alpha.kubernetes-incubator.io/nfd-cpuid-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-rdt-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true"
 }
 ```
 
@@ -179,7 +179,7 @@ following example shows how to target nodes with Intel TurboBoost enabled.
             }
         ],
         "nodeSelector": {
-                "node.alpha.intel.com/nfd-pstate-turbo": "true"
+                "node.alpha.kubernetes-incubator.io/nfd-pstate-turbo": "true"
         }
     }
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ const (
 	ProgramName = "node-feature-discovery"
 
 	// Namespace is the prefix for all published labels.
-	Namespace = "node.alpha.intel.com"
+	Namespace = "node.alpha.kubernetes-incubator.io"
 
 	// PodNameEnv is the environment variable that contains this pod's name.
 	PodNameEnv = "POD_NAME"


### PR DESCRIPTION
Fixes #27.
- Changed prefix from `node.alpha.intel.com/nfd` to
  `node.alpha.kubernetes-incubator.io/nfd`
