### PR TITLE
Fixes #21: Splits label/version output to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,12 @@ var (
 	prefix  = fmt.Sprintf("%s/nfd", Namespace)
 )
 
+// package loggers
+var (
+	stdoutLogger = log.New(os.Stdout, "", log.LstdFlags)
+	stderrLogger = log.New(os.Stderr, "", log.LstdFlags)
+)
+
 // Labels are a Kubernetes representation of discovered features.
 type Labels map[string]string
 
@@ -55,7 +61,7 @@ type APIHelpers interface {
 func main() {
 	// Assert that the version is known
 	if version == "" {
-		log.Fatalf("main.version not set! Set -ldflags \"-X main.version `git describe --tags --dirty --always`\" during build or run.")
+		stderrLogger.Fatalf("main.version not set! Set -ldflags \"-X main.version `git describe --tags --dirty --always`\" during build or run.")
 	}
 
 	usage := fmt.Sprintf(`%s.
@@ -111,29 +117,30 @@ func main() {
 	// compile whiteListArg regex
 	labelWhiteList, err := regexp.Compile(whiteListArg)
 	if err != nil {
-		log.Fatalf("Error parsing whitelist regex (%s): %s", whiteListArg, err)
+		stderrLogger.Fatalf("Error parsing whitelist regex (%s): %s", whiteListArg, err)
 	}
 
 	labels := Labels{}
 	// Add the version of this discovery code as a node label
 	versionLabel := fmt.Sprintf("%s/%s.version", Namespace, ProgramName)
 	labels[versionLabel] = version
+
 	// Log version label.
-	log.Printf("%s = %s", versionLabel, version)
+	stdoutLogger.Printf("%s = %s", versionLabel, version)
 
 	// Do feature discovery from all configured sources.
 	for _, source := range sources {
 		labelsFromSource, err := getFeatureLabels(source)
 		if err != nil {
-			log.Fatalf("discovery failed for source [%s]: %s", source.Name(), err.Error())
+			stderrLogger.Fatalf("discovery failed for source [%s]: %s", source.Name(), err.Error())
 		}
 
 		for name, value := range labelsFromSource {
 			// Log discovered feature.
-			log.Printf("%s = %s", name, value)
+			stdoutLogger.Printf("%s = %s", name, value)
 			// Skip if label doesn't match labelWhiteList
 			if !labelWhiteList.Match([]byte(name)) {
-				log.Printf("%s does not match the whitelist (%s) and will not be published.", name, whiteListArg)
+				stderrLogger.Printf("%s does not match the whitelist (%s) and will not be published.", name, whiteListArg)
 				continue
 			}
 			labels[name] = value
@@ -145,7 +152,7 @@ func main() {
 		helper := APIHelpers(k8sHelpers{})
 		err := advertiseFeatureLabels(helper, labels)
 		if err != nil {
-			log.Fatalf("failed to advertise labels: %s", err.Error())
+			stderrLogger.Fatalf("failed to advertise labels: %s", err.Error())
 		}
 	}
 }
@@ -170,14 +177,14 @@ func advertiseFeatureLabels(helper APIHelpers, labels Labels) error {
 	// Set up K8S client.
 	cli, err := helper.GetClient()
 	if err != nil {
-		log.Printf("can't get kubernetes client: %s", err.Error())
+		stderrLogger.Printf("can't get kubernetes client: %s", err.Error())
 		return err
 	}
 
 	// Get the current node.
 	node, err := helper.GetNode(cli)
 	if err != nil {
-		log.Printf("failed to get node: %s", err.Error())
+		stderrLogger.Printf("failed to get node: %s", err.Error())
 		return err
 	}
 
@@ -187,7 +194,7 @@ func advertiseFeatureLabels(helper APIHelpers, labels Labels) error {
 	// Send the updated node to the apiserver.
 	err = helper.UpdateNode(cli, node)
 	if err != nil {
-		log.Printf("can't update node: %s", err.Error())
+		stderrLogger.Printf("can't update node: %s", err.Error())
 		return err
 	}
 
@@ -211,20 +218,20 @@ func (h k8sHelpers) GetNode(cli *client.Client) (*api.Node, error) {
 	// Get the pod name and pod namespace from the env variables
 	podName := os.Getenv(PodNameEnv)
 	podns := os.Getenv(PodNamespaceEnv)
-	log.Printf("%s: %s", PodNameEnv, podName)
-	log.Printf("%s: %s", PodNamespaceEnv, podns)
+	stdoutLogger.Printf("%s: %s", PodNameEnv, podName)
+	stdoutLogger.Printf("%s: %s", PodNamespaceEnv, podns)
 
 	// Get the pod object using the pod name and pod namespace
 	pod, err := cli.Pods(podns).Get(podName)
 	if err != nil {
-		log.Printf("can't get pods: %s", err.Error())
+		stderrLogger.Printf("can't get pods: %s", err.Error())
 		return nil, err
 	}
 
 	// Get the node object using the pod name and pod namespace
 	node, err := cli.Nodes().Get(pod.Spec.NodeName)
 	if err != nil {
-		log.Printf("can't get node: %s", err.Error())
+		stderrLogger.Printf("can't get node: %s", err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
Previously the output for labels/nfd version was output to stderr along with errors. This PR adds stderr/stdout loggers and outputs labels/nfd version to stdout. This doesn't change the output on the terminal but it does allow another tool to deal with stdout and errors separately. 

Before:

```
-% docker run quay.io/kubernetes_incubator/node-feature-discovery:419702fc3dc8 2> error

-% cat error                                                                                                                                                                                                                                                                                    
2016-10-28 21:26:44.023070 I | node.alpha.intel.com/node-feature-discovery.version = 769caf8-dirty
2016-10-28 21:26:44.023294 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSE4.1 = true
2016-10-28 21:26:44.023330 I | node.alpha.intel.com/769caf8-dirty-cpuid-BMI1 = true
2016-10-28 21:26:44.023341 I | node.alpha.intel.com/769caf8-dirty-cpuid-CLMUL = true
2016-10-28 21:26:44.023348 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSE2 = true
2016-10-28 21:26:44.023357 I | node.alpha.intel.com/769caf8-dirty-cpuid-AVX = true
2016-10-28 21:26:44.023363 I | node.alpha.intel.com/769caf8-dirty-cpuid-AVX2 = true
2016-10-28 21:26:44.023371 I | node.alpha.intel.com/769caf8-dirty-cpuid-HTT = true
2016-10-28 21:26:44.023377 I | node.alpha.intel.com/769caf8-dirty-cpuid-CMOV = true
2016-10-28 21:26:44.023387 I | node.alpha.intel.com/769caf8-dirty-cpuid-NX = true
2016-10-28 21:26:44.023399 I | node.alpha.intel.com/769caf8-dirty-cpuid-MMX = true
2016-10-28 21:26:44.023405 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSE = true
2016-10-28 21:26:44.023414 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSE3 = true
2016-10-28 21:26:44.023422 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSE4.2 = true
2016-10-28 21:26:44.023432 I | node.alpha.intel.com/769caf8-dirty-cpuid-FMA3 = true
2016-10-28 21:26:44.023441 I | node.alpha.intel.com/769caf8-dirty-cpuid-BMI2 = true
2016-10-28 21:26:44.023451 I | node.alpha.intel.com/769caf8-dirty-cpuid-AESNI = true
2016-10-28 21:26:44.023461 I | node.alpha.intel.com/769caf8-dirty-cpuid-RDRAND = true
2016-10-28 21:26:44.023471 I | node.alpha.intel.com/769caf8-dirty-cpuid-RDTSCP = true
2016-10-28 21:26:44.023480 I | node.alpha.intel.com/769caf8-dirty-cpuid-CX16 = true
2016-10-28 21:26:44.023486 I | node.alpha.intel.com/769caf8-dirty-cpuid-MMXEXT = true
2016-10-28 21:26:44.023494 I | node.alpha.intel.com/769caf8-dirty-cpuid-SSSE3 = true
2016-10-28 21:26:44.023500 I | node.alpha.intel.com/769caf8-dirty-cpuid-F16C = true
2016-10-28 21:26:44.023510 I | node.alpha.intel.com/769caf8-dirty-cpuid-LZCNT = true
2016-10-28 21:26:44.023515 I | node.alpha.intel.com/769caf8-dirty-cpuid-POPCNT = true
2016-10-28 21:26:44.023523 I | node.alpha.intel.com/769caf8-dirty-cpuid-ERMS = true
2016-10-28 21:26:44.033911 I | node.alpha.intel.com/769caf8-dirty-rdt-RDTMON = true
2016-10-28 21:26:44.034034 I | node.alpha.intel.com/769caf8-dirty-pstate-turbo = true
2016-10-28 21:26:44.034061 I | can't get kubernetes client: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2016-10-28 21:26:44.034069 I | failed to advertise labels: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```

After:

```
-% docker run quay.io/kubernetes_incubator/node-feature-discovery:5927cfc0a79f 2> error
2016/10/28 21:28:00 node.alpha.intel.com/node-feature-discovery.version = be5a271-dirty
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-NX = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSE = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSE4.1 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-AVX2 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-F16C = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-BMI2 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-HTT = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-RDRAND = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-ERMS = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-CX16 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-CMOV = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-MMX = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-MMXEXT = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSE4.2 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-AVX = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-FMA3 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-BMI1 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-CLMUL = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSE2 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSE3 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-AESNI = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-SSSE3 = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-LZCNT = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-POPCNT = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-cpuid-RDTSCP = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-rdt-RDTMON = true
2016/10/28 21:28:00 node.alpha.intel.com/nfd-pstate-turbo = true

-% cat error
2016/10/28 21:28:00 can't get kubernetes client: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
2016/10/28 21:28:00 failed to advertise labels: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```
