### PR TITLE
Fixes #25: Deletes non-discovered nfd labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ the only label value published for features is the string `"true"`._
 
 The `--sources` flag controls which sources to use for discovery.
 
+_Note: Consecutive runs of node-feature-discovery will update the labels on a
+given node. If features are not discovered on a consecutive run, the corresponding
+label will be removed. This includes any restrictions placed on the consecutive run,
+such as restricting discovered features with the --label-whitelist option._
+
 ### Intel Resource Director Technology (RDT) Features
 
 | Feature name   | Description                                                                         |

--- a/mockapihelpers.go
+++ b/mockapihelpers.go
@@ -58,6 +58,12 @@ func (_m *MockAPIHelpers) GetNode(_a0 *client.Client) (*api.Node, error) {
 	return r0, r1
 }
 
+// RemoveLabels provides a mock function with *api.Node and main.Labels as the input arguments and
+// no return value
+func (_m *MockAPIHelpers) RemoveLabels(_a0 *api.Node, _a1 string) {
+	_m.Called(_a0, _a1)
+}
+
 // AddLabels provides a mock function with *api.Node and main.Labels as the input arguments and
 // no return value
 func (_m *MockAPIHelpers) AddLabels(_a0 *api.Node, _a1 Labels) {


### PR DESCRIPTION
Took a stab at #25. Appreciate any feedback.

Modifies AddLabels() to first remove any non-discovered nfd labels from
the node labels before adding newly discovered labels.

Adds tests to main_test.go to test the behavior of AddLabels.

edit:

This deletes non-discovered labels including those that may not be "discovered" because of the whitelist option. Wanted to make sure I called that out.