### PR TITLE
Enabled graceful failure if discovery for a source fails.

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,9 @@ func main() {
 	for _, source := range sources {
 		labelsFromSource, err := getFeatureLabels(source)
 		if err != nil {
-			stderrLogger.Fatalf("discovery failed for source [%s]: %s", source.Name(), err.Error())
+			stderrLogger.Printf("discovery failed for source [%s]: %s", source.Name(), err.Error())
+			stderrLogger.Printf("continuing ...")
+			continue
 		}
 
 		for name, value := range labelsFromSource {
@@ -164,8 +166,15 @@ func main() {
 
 // getFeatureLabels returns node labels for features discovered by the
 // supplied source.
-func getFeatureLabels(source FeatureSource) (Labels, error) {
-	labels := Labels{}
+func getFeatureLabels(source FeatureSource) (labels Labels, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			stderrLogger.Printf("panic occured during discovery of source [%s]: %v", source.Name(), r)
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+
+	labels = Labels{}
 	features, err := source.Discover()
 	if err != nil {
 		return nil, err

--- a/main_test.go
+++ b/main_test.go
@@ -165,3 +165,18 @@ func TestRemoveLabels(t *testing.T) {
 		})
 	})
 }
+
+func TestGetFeatureLabels(t *testing.T) {
+	Convey("When I get feature labels and panic occurs during discovery of a feature source", t, func() {
+		fakePanicFeatureSource := FeatureSource(new(fakePanicSource))
+
+		returnedLabels, err := getFeatureLabels(fakePanicFeatureSource)
+		Convey("No label is returned", func() {
+			So(len(returnedLabels), ShouldEqual, 0)
+		})
+		Convey("Error is produced and panic error is returned", func() {
+			So(err, ShouldResemble, fmt.Errorf("fake panic error"))
+		})
+
+	})
+}

--- a/sources.go
+++ b/sources.go
@@ -102,19 +102,3 @@ func (s pstateSource) Discover() ([]string, error) {
 
 	return features, nil
 }
-
-////////////////////////////////////////////////////////////////////////////////
-// Fake Source (used only for testing)
-
-// Implements main.FeatureSource.
-type fakeSource struct{}
-
-func (s fakeSource) Name() string { return "fake" }
-func (s fakeSource) Discover() ([]string, error) {
-	features := []string{}
-
-	// Adding three fake features.
-	features = append(features, "fakefeature1", "fakefeature2", "fakefeature3")
-
-	return features, nil
-}

--- a/test_sources.go
+++ b/test_sources.go
@@ -1,0 +1,28 @@
+package main
+
+////////////////////////////////////////////////////////////////////////////////
+// Fake Source (used only for testing)
+
+// Implements main.FeatureSource.
+type fakeSource struct{}
+
+func (s fakeSource) Name() string { return "fake" }
+func (s fakeSource) Discover() ([]string, error) {
+	features := []string{}
+
+	// Adding three fake features.
+	features = append(features, "fakefeature1", "fakefeature2", "fakefeature3")
+
+	return features, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Fake Panic Source (used only for testing)
+
+// Implements main.FeatureSource.
+type fakePanicSource struct{}
+
+func (s fakePanicSource) Name() string { return "fakepanic" }
+func (s fakePanicSource) Discover() ([]string, error) {
+	panic("fake panic error")
+}


### PR DESCRIPTION
Fixes #37.
- Handles errors from discovery of source.
- Handles panics from discovery of source using recover().
- Added tests.

Before: 
```sh
>docker run quay.io/kubernetes_incubator/node-feature-discovery:e7f35ed --sources=cpuid,pstate,fake --no-publish
2016/11/15 22:39:55 node.alpha.intel.com/node-feature-discovery.version = e7f35ed-dirty
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-NX = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-MMX = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSE = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSE4.2 = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-RDTSCP = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-RDSEED = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-MMXEXT = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSE3 = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-AVX = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-LZCNT = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-POPCNT = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-CMOV = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSSE3 = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-AESNI = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-CLMUL = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSE2 = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-SSE4.1 = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-RDRAND = true
2016/11/15 22:39:55 node.alpha.intel.com/nfd-cpuid-CX16 = true
2016/11/15 22:39:55 discovery failed for source [pstate]: can't detect whether turbo boost is enabled: open /sys/devices/system/cpu/intel_pstate/no_turbo: no such file or directory
```

After:
```sh
>docker run quay.io/kubernetes_incubator/node-feature-discovery:e7f35ed-dirty --sources=cpuid,pstate,fake --no-publish
2016/11/15 22:38:55 node.alpha.intel.com/node-feature-discovery.version = e7f35ed-dirty
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-RDTSCP = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-CMOV = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-MMX = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSE2 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-RDSEED = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSE = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSE4.2 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-AESNI = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-POPCNT = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-CX16 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-MMXEXT = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSSE3 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSE4.1 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-LZCNT = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-RDRAND = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-NX = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-SSE3 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-AVX = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-cpuid-CLMUL = true
2016/11/15 22:38:55 discovery failed for source [pstate]: can't detect whether turbo boost is enabled: open /sys/devices/system/cpu/intel_pstate/no_turbo: no such file or directory
2016/11/15 22:38:55 continuing ...
2016/11/15 22:38:55 node.alpha.intel.com/nfd-fake-fakefeature1 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-fake-fakefeature2 = true
2016/11/15 22:38:55 node.alpha.intel.com/nfd-fake-fakefeature3 = true
```