### PR TITLE
Upated RDT Discovery() to use exit status

### DIFF
--- a/rdt-discovery/l2-allocation-discovery.c
+++ b/rdt-discovery/l2-allocation-discovery.c
@@ -10,18 +10,16 @@ int main(int argc, char *argv[]) {
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 15))) {
     det = 0;
-    printf("NOT DETECTED");
+    return EXIT_FAILURE;
   }
   else {
     lcpuid(0x10, 0x0, &res);
     if (!(res.ebx & (1 << 2))) {
       det = 0;
-      printf("NOT DETECTED");
+      return EXIT_FAILURE;
     }
   }
 
   if (det)
-    printf("DETECTED");
-
-  return 0;
+    return EXIT_SUCCESS;
 }

--- a/rdt-discovery/l3-allocation-discovery.c
+++ b/rdt-discovery/l3-allocation-discovery.c
@@ -13,18 +13,16 @@ int main(int argc, char *argv[]) {
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 15))) {
     det = 0;
-    printf("NOT DETECTED");
+    return EXIT_FAILURE;
   }
   else {
     lcpuid(0x10, 0x0, &res);
     if (!(res.ebx & (1 << 1))) {
       det = 0;
-      printf("NOT DETECTED");
+      return EXIT_FAILURE;
     }
   }
 
   if (det)
-    printf("DETECTED");
-
-  return 0;
+    return EXIT_SUCCESS;
 }

--- a/rdt-discovery/monitoring-discovery.c
+++ b/rdt-discovery/monitoring-discovery.c
@@ -10,18 +10,16 @@ int main(int argc, char *argv[]) {
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 12))) {
     det = 0;
-    printf("NOT DETECTED");
+    return EXIT_FAILURE;
   }
   else {
     lcpuid(0xf, 0x0, &res);
     if (!(res.edx & (1 << 1))) {
       det=0;
-      printf("NOT DETECTED");
+      return EXIT_FAILURE;
     }
   }
 
   if (det)
-    printf("DETECTED");
-
-  return 0;
+    return EXIT_SUCCESS;
 }

--- a/sources.go
+++ b/sources.go
@@ -19,9 +19,6 @@ type FeatureSource interface {
 }
 
 const (
-	// DETECTED is compared with stdout for RDT detection helper programs.
-	DETECTED = "DETECTED"
-
 	// RDTBin is the path to RDT detection helpers.
 	RDTBin = "/go/src/github.com/kubernetes-incubator/node-feature-discovery/rdt-discovery"
 )
@@ -50,30 +47,27 @@ func (s rdtSource) Name() string { return "rdt" }
 func (s rdtSource) Discover() ([]string, error) {
 	features := []string{}
 
-	out, err := exec.Command("bash", "-c", path.Join(RDTBin, "mon-discovery")).Output()
-	if err != nil {
-		return nil, fmt.Errorf("can't detect support for RDT monitoring: %s", err.Error())
-	}
-	if string(out[:]) == DETECTED {
+	cmd := exec.Command("bash", "-c", path.Join(RDTBin, "mon-discovery"))
+	if err := cmd.Run(); err != nil {
+		stderrLogger.Printf("support for RDT monitoring was not detected: %s", err.Error())
+	} else {
 		// RDT monitoring detected.
 		features = append(features, "RDTMON")
 	}
 
-	out, err = exec.Command("bash", "-c", path.Join(RDTBin, "l3-alloc-discovery")).Output()
-	if err != nil {
-		return nil, fmt.Errorf("can't detect support for RDT L3 allocation: %s", err.Error())
-	}
-	if string(out[:]) == DETECTED {
-		// RDT L3 cache allocation detected.
+	cmd = exec.Command("bash", "-c", path.Join(RDTBin, "l3-alloc-discovery"))
+	if err := cmd.Run(); err != nil {
+		stderrLogger.Printf("support for RDT L3 allocation was not detected: %s", err.Error())
+	} else {
+		// RDT monitoring detected.
 		features = append(features, "RDTL3CA")
 	}
 
-	out, err = exec.Command("bash", "-c", path.Join(RDTBin, "l2-alloc-discovery")).Output()
-	if err != nil {
-		return nil, fmt.Errorf("can't detect support for RDT L2 allocation: %s", err.Error())
-	}
-	if string(out[:]) == DETECTED {
-		// RDT L2 cache allocation detected.
+	cmd = exec.Command("bash", "-c", path.Join(RDTBin, "l2-alloc-discovery"))
+	if err := cmd.Run(); err != nil {
+		stderrLogger.Printf("support for RDT L2 allocation was not detected: %s", err.Error())
+	} else {
+		// RDT monitoring detected.
 		features = append(features, "RDTL2CA")
 	}
 


### PR DESCRIPTION
Fixes #42 
- Updated RDT helper programs.

Manually tested. See below.

```sh
>docker run quay.io/kubernetes_incubator/node-feature-discovery:b44b054-dirty --no-publish
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/node-feature-discovery.version = b44b054-dirty
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSSE3 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-AESNI = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-CLMUL = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDSEED = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-CMOV = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-NX = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE4.1 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE4.2 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-AVX = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-MMX = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-MMXEXT = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE2 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE3 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-CX16 = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-LZCNT = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-POPCNT = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDRAND = true
2016/12/09 22:53:32 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDTSCP = true
2016/12/09 22:53:32 support for RDT monitoring was not detected: exit status 1
2016/12/09 22:53:32 support for RDT L3 allocation was not detected: exit status 1
2016/12/09 22:53:32 support for RDT L2 allocation was not detected: exit status 1
2016/12/09 22:53:32 discovery failed for source [pstate]: can't detect whether turbo boost is enabled: open /sys/devices/system/cpu/intel_pstate/no_turbo: no such file or directory
2016/12/09 22:53:32 continuing ...
```

```sh
root@d1k8s:~/balajismaniam/node-feature-discovery# docker run quay.io/kubernetes_incubator/node-feature-discovery:eef0a6c --no-publish
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/node-feature-discovery.version = eef0a6c-dirty
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSSE3 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE4.1 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-AESNI = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-MMX = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-FMA3 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-F16C = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-BMI1 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-CMOV = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-NX = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE3 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-AVX2 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-HTT = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-ADX = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-AVX = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-RTM = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDTSCP = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-POPCNT = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-HLE = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDRAND = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE2 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-CLMUL = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-CX16 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-MMXEXT = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-SSE4.2 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-LZCNT = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-BMI2 = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-RDSEED = true
2016/12/09 22:49:37 node.alpha.kubernetes-incubator.io/nfd-cpuid-ERMS = true
2016/12/09 22:49:38 node.alpha.kubernetes-incubator.io/nfd-rdt-RDTMON = true
2016/12/09 22:49:38 node.alpha.kubernetes-incubator.io/nfd-rdt-RDTL3CA = true
2016/12/09 22:49:38 support for RDT L2 allocation was not detected: exit status 1
2016/12/09 22:49:38 node.alpha.kubernetes-incubator.io/nfd-pstate-turbo = true
```