### PR TITLE
change label namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ const (
 	ProgramName = "node-feature-discovery"
 
 	// Namespace is the prefix for all published labels.
-	Namespace = "node.alpha.kubernetes-incubator.io"
+	Namespace = "nfd.alpha.kubernetes.io"
 
 	// PodNameEnv is the environment variable that contains this pod's name.
 	PodNameEnv = "POD_NAME"


### PR DESCRIPTION
Change nfd label to `nfd.alpha.kubernetes.io` according to [Kubernetes Community #300](https://github.com/kubernetes/community/issues/300) when in alpha phase.

How about we change nfd namespace according to nfd available phase like below:
* alpha 
  * `nfd.alpha.kubernetes.io`
* beta
  * `nfd.beta.kubernetes.io`
* GA(graduate from incubator) 
  * `nfd.kubernetes.io`

/cc @balajismaniam @ConnorDoyle @davidopp 