### PR TITLE
enable nfd framework on Arm64 platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,4 @@
-# Taken from https://github.com/docker-library/golang/blob/master/1.6/Dockerfile 
-# to build our golang image with debian testing (stretch).
-FROM buildpack-deps:stretch-scm
-
-# gcc for cgo.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-		g++ \
-		gcc \
-		libc6-dev \
-		make \
-	&& rm -rf /var/lib/apt/lists/*
-
-ENV GOLANG_VERSION 1.7.1
-ENV GOLANG_DOWNLOAD_URL https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ENV GOLANG_DOWNLOAD_SHA256 43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182
-
-RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
-	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
-WORKDIR $GOPATH
+FROM golang:1.8 
 
 # Build node feature discovery and set it as entrypoint.
 ADD . /go/src/github.com/kubernetes-incubator/node-feature-discovery
@@ -31,9 +6,18 @@ ADD . /go/src/github.com/kubernetes-incubator/node-feature-discovery
 WORKDIR /go/src/github.com/kubernetes-incubator/node-feature-discovery
 
 ARG NFD_VERSION
-RUN git clone --depth 1 https://github.com/01org/intel-cmt-cat.git
-RUN cd intel-cmt-cat/lib; make install
-RUN cd rdt-discovery; make
+
+RUN case $(dpkg --print-architecture) in \
+        arm64) \
+                echo "skip rdt on Arm64 platform" \
+                ;; \
+        *) \
+                git clone --depth 1 https://github.com/01org/intel-cmt-cat.git \
+                && cd intel-cmt-cat/lib; make install \
+                && cd ../../rdt-discovery; make \
+                ;; \
+        esac
+
 RUN go get github.com/Masterminds/glide
 RUN glide install --strip-vendor
 RUN go install \


### PR DESCRIPTION
   currently, nfd framework can't be work on Arm64 platform.
   Fix points:
   1, removed rdt on Arm64 platform
   2, optimized the code related to multi-arch

Change-Id: If605041f6d2243ae2afb3248edbf102083c6dcb4
Signed-off-by: Bin Lu <bin.lu@arm.com>
Jira: ENTOS-432