### PR TITLE
Get node name from spec.nodeName instead of indirectly from pod.

### DIFF
--- a/label-nodes.sh
+++ b/label-nodes.sh
@@ -5,8 +5,6 @@ NumNodes=$(kubectl get nodes | grep -i ready | wc -l)
 # We set the .spec.completions and .spec.parallelism to the node count
 # We request a specific hostPort in the job spec to limit the number of pods
 # that run on a node to one. As a result, one pod runs on each node in parallel
-# We set the POD_NAME and POD_NAMESPACE environemnt variables to the pod name 
-# and pod namespace. These enivornment variables are used by the feature 
-# discovery software to get the Kubernetes pod and node object. 
+# We set the NODE_NAME environemnt variable to get the Kubernetes node object.
 sed -e "s/COMPLETION_COUNT/$NumNodes/" -e "s/PARALLELISM_COUNT/$NumNodes/" node-feature-discovery-job.json.template > node-feature-discovery-job.json
 kubectl create -f node-feature-discovery-job.json

--- a/main.go
+++ b/main.go
@@ -28,12 +28,8 @@ const (
 	// Namespace is the prefix for all published labels.
 	Namespace = "node.alpha.kubernetes-incubator.io"
 
-	// PodNameEnv is the environment variable that contains this pod's name.
-	PodNameEnv = "POD_NAME"
-
-	// PodNamespaceEnv is the environment variable that contains this pod's
-	// namespace.
-	PodNamespaceEnv = "POD_NAMESPACE"
+	// NodeNameEnv is the environment variable that contains this node's name.
+	NodeNameEnv = "NODE_NAME"
 )
 
 var (
@@ -286,20 +282,11 @@ func (h k8sHelpers) GetClient() (*k8sclient.Clientset, error) {
 
 func (h k8sHelpers) GetNode(cli *k8sclient.Clientset) (*api.Node, error) {
 	// Get the pod name and pod namespace from the env variables
-	podName := os.Getenv(PodNameEnv)
-	podns := os.Getenv(PodNamespaceEnv)
-	stdoutLogger.Printf("%s: %s", PodNameEnv, podName)
-	stdoutLogger.Printf("%s: %s", PodNamespaceEnv, podns)
+	nodeName := os.Getenv(NodeNameEnv)
+	stdoutLogger.Printf("%s: %s", NodeNameEnv, nodeName)
 
-	// Get the pod object using the pod name and pod namespace
-	pod, err := cli.Core().Pods(podns).Get(podName, meta_v1.GetOptions{})
-	if err != nil {
-		stderrLogger.Printf("can't get pods: %s", err.Error())
-		return nil, err
-	}
-
-	// Get the node object using the pod name and pod namespace
-	node, err := cli.Core().Nodes().Get(pod.Spec.NodeName, meta_v1.GetOptions{})
+	// Get the node object using node name
+	node, err := cli.Core().Nodes().Get(nodeName, meta_v1.GetOptions{})
 	if err != nil {
 		stderrLogger.Printf("can't get node: %s", err.Error())
 		return nil, err

--- a/node-feature-discovery-job.json.template
+++ b/node-feature-discovery-job.json.template
@@ -22,18 +22,10 @@
           {
             "env": [
               {
-                "name": "POD_NAME",
+                "name": "NODE_NAME",
                 "valueFrom": {
                   "fieldRef": {
-                    "fieldPath": "metadata.name"
-                  }
-                }
-              },
-              {
-                "name": "POD_NAMESPACE",
-                "valueFrom": {
-                  "fieldRef": {
-                    "fieldPath": "metadata.namespace"
+                    "fieldPath": "spec.nodeName"
                   }
                 }
               }


### PR DESCRIPTION
spec.nodeName allows to get node name directly, without
using pod and podnamespace as intermediate steps.

This PR resolves #41