### PR TITLE
Added nonrotational storage detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node-feature-discovery.
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network]
+                              [Default: cpuid,rdt,pstate,network,storage]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -58,6 +58,7 @@ The current set of feature sources are the following:
 - [Intel Resource Director Technology][intel-rdt]
 - [Intel P-State driver][intel-pstate]
 - Network
+- Storage
 
 ### Feature labels
 
@@ -79,7 +80,8 @@ the only label value published for features is the string `"true"`._
   "node.alpha.kubernetes-incubator.io/nfd-cpuid-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-rdt-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true"
+  "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-storage-<feature-name>": "true"
 }
 ```
 
@@ -117,6 +119,12 @@ such as restricting discovered features with the --label-whitelist option._
 | Feature name   | Description                                                                         |
 | :------------: | :---------------------------------------------------------------------------------: |
 | [SRIOV][sriov] | Single Root Input/Output Virtualization (SR-IOV) enabled Network Interface Card
+
+### Storage Features
+
+| Feature name       | Description                                                                         |
+| :--------------:   | :---------------------------------------------------------------------------------: |
+| nonrotationaldisk  | Non-rotational disk, like SSD, is present in the node
 
 ## Getting started
 ### System requirements

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubernetes-incubator/node-feature-discovery/source/network"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/panic_fake"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/pstate"
+	"github.com/kubernetes-incubator/node-feature-discovery/source/storage"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/rdt"
 	api "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,7 +109,7 @@ func argsParse(argv []string) (noPublish bool, sourcesArg []string, whiteListArg
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network]
+                              [Default: cpuid,rdt,pstate,network,storage]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -144,6 +145,7 @@ func configureParameters(sourcesArg []string, whiteListArg string) (sources []so
 		rdt.Source{},
 		pstate.Source{},
 		network.Source{},
+		storage.Source{},
 		fake.Source{},
 		panic_fake.Source{},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -132,7 +132,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("noPublish is set and sourcesArg is set to the default value", func() {
 				So(noPublish, ShouldBeTrue)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network", "storage"})
 				So(len(whiteListArg), ShouldEqual, 0)
 			})
 		})
@@ -152,7 +152,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("whiteListArg is set to appropriate value and sourcesArg is set to default value", func() {
 				So(noPublish, ShouldBeFalse)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network", "storage"})
 				So(whiteListArg, ShouldResemble, ".*rdt.*")
 			})
 		})

--- a/source/storage/storage.go
+++ b/source/storage/storage.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+// Source implements FeatureSource.
+type Source struct{}
+
+// Name returns an identifier string for this feature source.
+func (s Source) Name() string { return "storage" }
+
+// Discover returns feature names for storage: nonrotationaldisk if any SSD drive present.
+func (s Source) Discover() ([]string, error) {
+	features := []string{}
+
+	// Check if there is any non-rotational block devices attached to the node
+	blockdevices, err := ioutil.ReadDir("/sys/block/")
+	if err == nil {
+		for _, bdev := range blockdevices {
+			fname := "/sys/block/" + bdev.Name() + "/queue/rotational"
+			bytes, err := ioutil.ReadFile(fname)
+			if err != nil {
+				return nil, fmt.Errorf("can't read rotational status: %s", err.Error())
+			}
+			if bytes[0] == byte('0') {
+				// Non-rotational storage is present, add label.
+				features = append(features, "nonrotationaldisk")
+				break
+			}
+		}
+	}
+	return features, nil
+}


### PR DESCRIPTION
Add label if any non-rotational block device is present in the node.
The label will be: nfd-storage-nonrotational=true
This change also adds feature source "storage".

Fixes #85 

Note that during label creation it is not known how devices are actually
used by pods, so the approach is simplistic, and more sophisticated
logic will be needed at some level to make precise decisions.
But labeling "if any SSD present" should cover simple cases reasonably.