### PR TITLE
Add memory source and NUMA detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node-feature-discovery.
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network,storage]
+                              [Default: cpuid,rdt,pstate,memory,network,storage]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -57,6 +57,7 @@ The current set of feature sources are the following:
 - [CPUID][cpuid] for x86 CPU details
 - [Intel Resource Director Technology][intel-rdt]
 - [Intel P-State driver][intel-pstate]
+- Memory
 - Network
 - Storage
 
@@ -80,6 +81,7 @@ the only label value published for features is the string `"true"`._
   "node.alpha.kubernetes-incubator.io/nfd-cpuid-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-rdt-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-memory-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-storage-<feature-name>": "true"
 }
@@ -113,6 +115,12 @@ such as restricting discovered features with the --label-whitelist option._
 | SSE4.1         | Streaming SIMD Extensions 4.1 (SSE4.1)
 | SSE4.2         | Streaming SIMD Extensions 4.2 (SSE4.2)
 | SGX            | Software Guard Extensions (SGX)
+
+### Memory Features
+
+| Feature name   | Description                                                                         |
+| :------------: | :---------------------------------------------------------------------------------: |
+| numa           | Multiple memory nodes i.e. NUMA architecture detected
 
 ### Network Features
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubernetes-incubator/node-feature-discovery/source"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/cpuid"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/fake"
+	"github.com/kubernetes-incubator/node-feature-discovery/source/memory"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/network"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/panic_fake"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/pstate"
@@ -109,7 +110,7 @@ func argsParse(argv []string) (noPublish bool, sourcesArg []string, whiteListArg
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,network,storage]
+                              [Default: cpuid,rdt,pstate,memory,network,storage]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -144,6 +145,7 @@ func configureParameters(sourcesArg []string, whiteListArg string) (sources []so
 		cpuid.Source{},
 		rdt.Source{},
 		pstate.Source{},
+		memory.Source{},
 		network.Source{},
 		storage.Source{},
 		fake.Source{},

--- a/main_test.go
+++ b/main_test.go
@@ -132,7 +132,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("noPublish is set and sourcesArg is set to the default value", func() {
 				So(noPublish, ShouldBeTrue)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network", "storage"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage"})
 				So(len(whiteListArg), ShouldEqual, 0)
 			})
 		})
@@ -152,7 +152,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("whiteListArg is set to appropriate value and sourcesArg is set to default value", func() {
 				So(noPublish, ShouldBeFalse)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "network", "storage"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage"})
 				So(whiteListArg, ShouldResemble, ".*rdt.*")
 			})
 		})

--- a/source/memory/memory.go
+++ b/source/memory/memory.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// Source implements FeatureSource.
+type Source struct{}
+
+// Name returns an identifier string for this feature source.
+func (s Source) Name() string { return "memory" }
+
+// Discover returns feature names for memory: numa if more than one memory node is present.
+func (s Source) Discover() ([]string, error) {
+	features := []string{}
+
+	// Find out how many nodes are online
+	// Multiple nodes is a sign of NUMA
+	bytes, err := ioutil.ReadFile("/sys/devices/system/node/online")
+	if err != nil {
+		return nil, fmt.Errorf("can't read /sys/devices/system/node/online: %s", err.Error())
+	}
+	// File content is expected to be:
+	//   "0\n" in one-node case
+	//   "0-K\n" in N-node case where K=N-1
+	// presence of newline requires TrimSpace
+	if strings.TrimSpace(string(bytes)) != "0" {
+		// more than one node means NUMA
+		features = append(features, "numa")
+	}
+
+	return features, nil
+}


### PR DESCRIPTION
If multiple nodes are marked online in
/sys/devices/system/node/online, it's a sign of NUMA
architecture. Mark it using nfd-memory-numa label.

Fixes #84 

Here is one way of detecting NUMA architecture based on number of online nodes.
Please comment if you see some problems with such detection.
I have verified it on single-node and 2- and 4-node NUMA systems.