### PR TITLE
Make intel-cmt-cat a git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node-feature-discovery-job.json
 vendor/
 demo/helper-scripts/*.pdf
 demo/helper-scripts/*.log
-intel-cmt-cat/
 rdt-discovery/l2-alloc-discovery
 rdt-discovery/l3-alloc-discovery
 rdt-discovery/mon-discovery

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "intel-cmt-cat"]
+	path = intel-cmt-cat
+	url = https://github.com/intel/intel-cmt-cat

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /go/src/github.com/kubernetes-incubator/node-feature-discovery
 
 ENV PATH="/go/src/github.com/kubernetes-incubator/node-feature-discovery/rdt-discovery:${PATH}"
 
-ENV CMT_CAT_SRCDIR="/go/src/github.com/kubernetes-incubator/node-feature-discovery/intel-cmt-cat"
-
 ARG NFD_VERSION
 
 RUN case $(dpkg --print-architecture) in \
@@ -16,9 +14,8 @@ RUN case $(dpkg --print-architecture) in \
                 echo "skip rdt on Arm64 platform" \
                 ;; \
         *) \
-                git clone --depth 1 https://github.com/01org/intel-cmt-cat.git \
-                && cd intel-cmt-cat/lib; make install \
-                && cd ../../rdt-discovery; make \
+                make -C intel-cmt-cat/lib install && \
+                make -C rdt-discovery \
                 ;; \
         esac
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ to the node to advertise hardware features (initially, from `cpuid`, RDT, p-stat
 Download the source code.
 
 ```
-git clone https://github.com/kubernetes-incubator/node-feature-discovery
+git clone --recurse-submodules https://github.com/kubernetes-incubator/node-feature-discovery
 ```
 
 **Build the Docker image:**

--- a/rdt-discovery/Makefile
+++ b/rdt-discovery/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 LIBDIR=/usr/local/lib
-INCDIR=$(CMT_CAT_SRCDIR)/lib/
+INCDIR=../intel-cmt-cat/lib/
 
 LDFLAGS=-L$(LIBDIR)
 LDLIBS=-lpqos


### PR DESCRIPTION
This makes the build more deterministic. Previously, nfd just blindly
took the tip revision from intel-cmt-cat master branch which could brake
the build without any changes in nfd itself.