### PR TITLE
Add label to advertise selinux status

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ node-feature-discovery.
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,memory,network,storage]
+                              [Default: cpuid,rdt,pstate,memory,network,storage,selinux]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -60,6 +60,7 @@ The current set of feature sources are the following:
 - Memory
 - Network
 - Storage
+- Selinux
 
 ### Feature labels
 
@@ -83,7 +84,8 @@ the only label value published for features is the string `"true"`._
   "node.alpha.kubernetes-incubator.io/nfd-pstate-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-memory-<feature-name>": "true",
   "node.alpha.kubernetes-incubator.io/nfd-network-<feature-name>": "true",
-  "node.alpha.kubernetes-incubator.io/nfd-storage-<feature-name>": "true"
+  "node.alpha.kubernetes-incubator.io/nfd-storage-<feature-name>": "true",
+  "node.alpha.kubernetes-incubator.io/nfd-selinux-<feature-name>": "true"
 }
 ```
 
@@ -133,6 +135,12 @@ such as restricting discovered features with the --label-whitelist option._
 | Feature name       | Description                                                                         |
 | :--------------:   | :---------------------------------------------------------------------------------: |
 | nonrotationaldisk  | Non-rotational disk, like SSD, is present in the node
+
+### Selinux Features
+
+| Feature name       | Description                                                                         |
+| :--------------:   | :---------------------------------------------------------------------------------: |
+| selinux            | selinux is enabled on the node
 
 ## Getting started
 ### System requirements

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubernetes-incubator/node-feature-discovery/source/pstate"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/storage"
 	"github.com/kubernetes-incubator/node-feature-discovery/source/rdt"
+	"github.com/kubernetes-incubator/node-feature-discovery/source/selinux"
 	api "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -110,7 +111,7 @@ func argsParse(argv []string) (noPublish bool, sourcesArg []string, whiteListArg
   -h --help                   Show this screen.
   --version                   Output version and exit.
   --sources=<sources>         Comma separated list of feature sources.
-                              [Default: cpuid,rdt,pstate,memory,network,storage]
+                              [Default: cpuid,rdt,pstate,memory,network,storage,selinux]
   --no-publish                Do not publish discovered features to the
                               cluster-local Kubernetes API server.
   --label-whitelist=<pattern> Regular expression to filter label names to
@@ -148,6 +149,7 @@ func configureParameters(sourcesArg []string, whiteListArg string) (sources []so
 		memory.Source{},
 		network.Source{},
 		storage.Source{},
+		selinux.Source{},
 		fake.Source{},
 		panic_fake.Source{},
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -132,7 +132,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("noPublish is set and sourcesArg is set to the default value", func() {
 				So(noPublish, ShouldBeTrue)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage", "selinux"})
 				So(len(whiteListArg), ShouldEqual, 0)
 			})
 		})
@@ -152,7 +152,7 @@ func TestArgsParse(t *testing.T) {
 
 			Convey("whiteListArg is set to appropriate value and sourcesArg is set to default value", func() {
 				So(noPublish, ShouldBeFalse)
-				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage"})
+				So(sourcesArg, ShouldResemble, []string{"cpuid", "rdt", "pstate", "memory", "network", "storage","selinux"})
 				So(whiteListArg, ShouldResemble, ".*rdt.*")
 			})
 		})

--- a/node-feature-discovery-job.json.template
+++ b/node-feature-discovery-job.json.template
@@ -17,7 +17,7 @@
         }
       },
       "spec": {
-	"hostNetwork": true,
+        "hostNetwork": true,
         "containers": [
           {
             "env": [
@@ -37,10 +37,24 @@
                 "containerPort": 7156,
                 "hostPort": 7156
               }
+            ],
+            "volumeMounts": [
+              {
+                "name": "host-sys",
+                "mountPath": "/host-sys"
+              }
             ]
           }
         ],
-        "restartPolicy": "Never"
+        "restartPolicy": "Never",
+        "volumes": [
+          {
+            "name": "host-sys",
+            "hostPath": {
+              "path": "/sys"
+            }
+          }
+        ]
       }
     }
   }

--- a/source/selinux/selinux.go
+++ b/source/selinux/selinux.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinux
+
+import (
+	"io/ioutil"
+	"fmt"
+)
+
+type Source struct{}
+
+func (s Source) Name() string { return "selinux" }
+
+func (s Source) Discover() ([]string, error) {
+	features := []string{}
+	status, err := ioutil.ReadFile("/host-sys/fs/selinux/enforce")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to detect the status of selinux, please check if the system supports selinux and make sure /sys on the host is mounted into the container: %s", err.Error())
+	}
+	if status[0] == byte('1') {
+		// selinux is enabled.
+		features = append(features, "enabled")
+	}
+	return features, nil
+}


### PR DESCRIPTION
This commit:
- enables node-feature-dicovery to advertise selinux status
  on the node by adding a label.
- update the template to mount /sys into the container, this is
  needed to know about the selinux status on the host
- adds selinux source for unit tests