### PR TITLE
Use a specific released version of intel-cmt-cat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/kubernetes-incubator/node-feature-discovery
 
 ENV PATH="/go/src/github.com/kubernetes-incubator/node-feature-discovery/rdt-discovery:${PATH}"
 
-ENV CMT_CAT_SRCDIR="/go/src/github.com/kubernetes-incubator/node-feature-discovery/intel-cmt-cat"
+ENV CMT_CAT_VERSION="v1.2.0"
 
 ARG NFD_VERSION
 
@@ -16,9 +16,9 @@ RUN case $(dpkg --print-architecture) in \
                 echo "skip rdt on Arm64 platform" \
                 ;; \
         *) \
-                git clone --depth 1 https://github.com/01org/intel-cmt-cat.git \
-                && cd intel-cmt-cat/lib; make install \
-                && cd ../../rdt-discovery; make \
+                git clone --depth 1 -b $CMT_CAT_VERSION https://github.com/01org/intel-cmt-cat.git && \
+                make -C intel-cmt-cat/lib install && \
+                make -C rdt-discovery \
                 ;; \
         esac
 

--- a/rdt-discovery/Makefile
+++ b/rdt-discovery/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 LIBDIR=/usr/local/lib
-INCDIR=$(CMT_CAT_SRCDIR)/lib/
+INCDIR=../intel-cmt-cat/lib/
 
 LDFLAGS=-L$(LIBDIR)
 LDLIBS=-lpqos


### PR DESCRIPTION
This makes the build more deterministic. Previously, nfd just blindly
took the tip revision from intel-cmt-cat master branch which could brake
the build without any changes in nfd itself.