### PR TITLE
rdt-discovery: update links to intel-cmt-cat source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN case $(dpkg --print-architecture) in \
                 echo "skip rdt on Arm64 platform" \
                 ;; \
         *) \
-                git clone --depth 1 -b $CMT_CAT_VERSION https://github.com/01org/intel-cmt-cat.git && \
+                git clone --depth 1 -b $CMT_CAT_VERSION https://github.com/intel/intel-cmt-cat.git && \
                 make -C intel-cmt-cat/lib install && \
                 make -C rdt-discovery \
                 ;; \

--- a/rdt-discovery/l2-allocation-discovery.c
+++ b/rdt-discovery/l2-allocation-discovery.c
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   struct cpuid_out res;
 
-  // Logic below from https://github.com/01org/intel-cmt-cat/blob/master/lib/host_cap.c
+  // Logic below from https://github.com/intel/intel-cmt-cat/blob/master/lib/cap.c
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 15))) {
     return EXIT_FAILURE;

--- a/rdt-discovery/l3-allocation-discovery.c
+++ b/rdt-discovery/l3-allocation-discovery.c
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   struct cpuid_out res;
 
-  // Logic below from https://github.com/01org/intel-cmt-cat/blob/master/lib/host_cap.c
+  // Logic below from https://github.com/intel/intel-cmt-cat/blob/master/lib/cap.c
   // TODO(balajismaniam): Implement L3 CAT detection using brand string and MSR probing if
   // not detected using cpuid
   lcpuid(0x7, 0x0, &res);

--- a/rdt-discovery/monitoring-cmt-discovery.c
+++ b/rdt-discovery/monitoring-cmt-discovery.c
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   struct cpuid_out res;
 
-  // Logic below from https://github.com/01org/intel-cmt-cat/blob/master/lib/host_cap.c
+  // Logic below from https://github.com/intel/intel-cmt-cat/blob/master/lib/cap.c
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 12))) {
     return EXIT_FAILURE;

--- a/rdt-discovery/monitoring-discovery.c
+++ b/rdt-discovery/monitoring-discovery.c
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   struct cpuid_out res;
 
-  // Logic below from https://github.com/01org/intel-cmt-cat/blob/master/lib/host_cap.c
+  // Logic below from https://github.com/intel/intel-cmt-cat/blob/master/lib/cap.c
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 12))) {
     return EXIT_FAILURE;

--- a/rdt-discovery/monitoring-mbm-discovery.c
+++ b/rdt-discovery/monitoring-mbm-discovery.c
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   struct cpuid_out res;
 
-  // Logic below from https://github.com/01org/intel-cmt-cat/blob/master/lib/host_cap.c
+  // Logic below from https://github.com/intel/intel-cmt-cat/blob/master/lib/cap.c
   lcpuid(0x7, 0x0, &res);
   if (!(res.ebx & (1 << 12))) {
     return EXIT_FAILURE;


### PR DESCRIPTION
I discovered outdated links while I was preparing #120:
Source links in rdt-discovery point to 01org area repo which has changed, 
also cap.c source file name has changed.
In Dockerfile also it makes sense to use same repo name (although GH redirects the old name so it works qith both names).
This PR makes no functional changes.
