### PR TITLE
Utilize multi-stage build to reduce docker image size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ services:
 
 script:
     - docker build -t quay.io/kubernetes_incubator/node-feature-discovery .
-    - docker run --entrypoint=go quay.io/kubernetes_incubator/node-feature-discovery test

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN go test .
 
 
 # Create production image for running node feature discovery
-FROM golang:1.8
+FROM debian:stretch-slim
 
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/local/lib /usr/local/lib

--- a/rdt-discovery/Makefile
+++ b/rdt-discovery/Makefile
@@ -2,9 +2,19 @@ CC=gcc
 LIBDIR=/usr/local/lib
 INCDIR=../intel-cmt-cat/lib/
 
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+
 LDFLAGS=-L$(LIBDIR)
 LDLIBS=-lpqos
 CFLAGS=-I$(INCDIR)
+
+BINARIES = mon-discovery \
+		   mon-cmt-discovery \
+		   mon-mbm-discovery \
+		   l3-alloc-discovery \
+		   l2-alloc-discovery \
+		   mem-bandwidth-alloc-discovery
 
 default:
 	$(MAKE) all
@@ -15,3 +25,7 @@ all:
 	$(CC) $(CFLAGS) -o l3-alloc-discovery l3-allocation-discovery.c $(LDFLAGS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o l2-alloc-discovery l2-allocation-discovery.c $(LDFLAGS) $(LDLIBS)
 	$(CC) $(CFLAGS) -o mem-bandwidth-alloc-discovery mem-bandwidth-allocation-discovery.c $(LDFLAGS) $(LDLIBS)
+
+install:
+	install -d $(BINDIR)
+	install -t $(BINDIR) $(BINARIES)


### PR DESCRIPTION
This reduces the image basically to size of the debian stretch minimal base image. I.e. size drops from ~1.2GB to ~75MB. Targeted against #129 