### PR TITLE
Add kad to OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,4 @@ approvers:
   - ConnorDoyle
   - flyingcougar
   - marquiz
+  - kad


### PR DESCRIPTION
As backup reviewer/approver if other project members are away.