### PR TITLE
Implement nfdadm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN case $(dpkg --print-architecture) in \
 RUN go get github.com/Masterminds/glide
 RUN glide install --strip-vendor
 RUN go install \
-  -ldflags "-s -w -X main.version=$NFD_VERSION" \
+  -ldflags "-s -w -X github.com/kubernetes-incubator/node-feature-discovery/version.version=$NFD_VERSION" \
   github.com/kubernetes-incubator/node-feature-discovery
 
 ENTRYPOINT ["/go/bin/node-feature-discovery"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,8 @@ RUN glide install --strip-vendor
 RUN go install \
   -ldflags "-s -w -X github.com/kubernetes-incubator/node-feature-discovery/version.version=$NFD_VERSION" \
   github.com/kubernetes-incubator/node-feature-discovery
+RUN go install \
+  -ldflags "-s -w -X github.com/kubernetes-incubator/node-feature-discovery/version.version=$NFD_VERSION" \
+  github.com/kubernetes-incubator/node-feature-discovery/tools/nfdadm
 
 ENTRYPOINT ["/go/bin/node-feature-discovery"]

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,8 @@ docker:
 		--build-arg no_proxy=$(no_proxy) \
 		--build-arg NO_PROXY=$(NO_PROXY) \
 		-t $(QUAY_DOMAIN_NAME)/$(QUAY_REGISTRY_USER)/$(DOCKER_IMAGE_NAME):$(VERSION) ./
+
+nfdadm:
+	go install \
+		-ldflags "-s -w -X github.com/kubernetes-incubator/node-feature-discovery/version.version=$(VERSION)" \
+		github.com/kubernetes-incubator/node-feature-discovery/tools/nfdadm

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ DOCKER_IMAGE_NAME := node-feature-discovery
 
 VERSION := $(shell git describe --tags --dirty --always)
 
+DOCKER_TAG = $(QUAY_DOMAIN_NAME)/$(QUAY_REGISTRY_USER)/$(DOCKER_IMAGE_NAME):$(VERSION)
+
 all: docker
 
 # To override QUAY_REGISTRY_USER use the -e option as follows:
@@ -18,7 +20,12 @@ docker:
 		--build-arg HTTPS_PROXY=$(HTTPS_PROXY) \
 		--build-arg no_proxy=$(no_proxy) \
 		--build-arg NO_PROXY=$(NO_PROXY) \
-		-t $(QUAY_DOMAIN_NAME)/$(QUAY_REGISTRY_USER)/$(DOCKER_IMAGE_NAME):$(VERSION) ./
+		-t $(DOCKER_TAG) ./
+
+	@echo "Copying nfdadm tool from container..."
+	@container_id=`docker create $(DOCKER_TAG)`; \
+	docker cp $${container_id}:/go/bin/nfdadm .; \
+	docker rm -v $${container_id} > /dev/null
 
 nfdadm:
 	go install \

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 472684ea7631ee1754656f2dd2f76d419b3cb360c2339fdf8260e95e0f053726
-updated: 2018-02-21T13:16:26.752071939+02:00
+updated: 2018-06-14T15:01:56.68490961+03:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 87df7c60d5820d0f8ae11afede5aa52325c09717
@@ -20,9 +20,9 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
 - name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -31,7 +31,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
   - proto
   - ptypes
@@ -59,7 +59,7 @@ imports:
 - name: github.com/klauspost/cpuid
   version: ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da
 - name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
   - buffer
   - jlexer
@@ -67,7 +67,7 @@ imports:
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/PuerkitoBio/purell
@@ -79,15 +79,13 @@ imports:
 - name: github.com/stretchr/objx
   version: 8a3f7159479fbc75b30357fbc48f380b7320f08e
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - mock
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
-  - context
-  - context/ctxhttp
   - http2
   - http2/hpack
   - idna
@@ -128,6 +126,7 @@ imports:
   - certificates/v1beta1
   - core/v1
   - extensions/v1beta1
+  - imagepolicy/v1alpha1
   - networking/v1
   - policy/v1beta1
   - rbac/v1
@@ -138,21 +137,16 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 180eddb345a5be3a157cea1c624700ad5bd27b8f
   subpackages:
-  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
-  - pkg/apimachinery
-  - pkg/apimachinery/registered
-  - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
   - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
-  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/runtime
@@ -165,29 +159,20 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
-  - pkg/util/cache
   - pkg/util/clock
-  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
-  - pkg/util/httpstream
-  - pkg/util/httpstream/spdy
   - pkg/util/intstr
   - pkg/util/json
-  - pkg/util/mergepatch
   - pkg/util/net
-  - pkg/util/remotecommand
   - pkg/util/runtime
   - pkg/util/sets
-  - pkg/util/strategicpatch
   - pkg/util/validation
   - pkg/util/validation/field
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
   - pkg/watch
-  - third_party/forked/golang/json
-  - third_party/forked/golang/netutil
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
   version: 2ae454230481a7cb5544325e12ad7658ecccd19b
@@ -230,7 +215,7 @@ imports:
   - util/flowcontrol
   - util/integer
 - name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
+  version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1
   subpackages:
   - pkg/common
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a488111e226d9a9d752f9b533b5cba022a0f0ebf497b5d39c6381e54cc1c707e
-updated: 2018-06-14T15:04:55.35064782+03:00
+updated: 2018-06-14T15:07:18.544531386+03:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 87df7c60d5820d0f8ae11afede5aa52325c09717
@@ -50,6 +50,10 @@ imports:
   version: 787624de3eb7bd915c329cba748687a3b22666a6
   subpackages:
   - diskcache
+- name: github.com/howeyc/gopass
+  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
+- name: github.com/imdario/mergo
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/json-iterator/go
@@ -85,6 +89,10 @@ imports:
   subpackages:
   - assert
   - mock
+- name: golang.org/x/crypto
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
@@ -92,6 +100,11 @@ imports:
   - http2/hpack
   - idna
   - lex/httplex
+- name: golang.org/x/sys
+  version: 95c6576299259db960f6c5b9b69ea52422860fce
+  subpackages:
+  - unix
+  - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
@@ -217,12 +230,17 @@ imports:
   - pkg/version
   - rest
   - rest/watch
+  - tools/auth
+  - tools/clientcmd
   - tools/clientcmd/api
+  - tools/clientcmd/api/latest
+  - tools/clientcmd/api/v1
   - tools/metrics
   - tools/reference
   - transport
   - util/cert
   - util/flowcontrol
+  - util/homedir
   - util/integer
 - name: k8s.io/kube-openapi
   version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 472684ea7631ee1754656f2dd2f76d419b3cb360c2339fdf8260e95e0f053726
-updated: 2018-06-14T15:01:56.68490961+03:00
+hash: a488111e226d9a9d752f9b533b5cba022a0f0ebf497b5d39c6381e54cc1c707e
+updated: 2018-06-14T15:03:28.346074486+03:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 87df7c60d5820d0f8ae11afede5aa52325c09717
@@ -11,8 +11,6 @@ imports:
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
   - log
-- name: github.com/emicklei/go-restful-swagger12
-  version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/jsonpointer
@@ -20,9 +18,9 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
-  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -31,7 +29,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
   - ptypes
@@ -59,7 +57,7 @@ imports:
 - name: github.com/klauspost/cpuid
   version: ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da
 - name: github.com/mailru/easyjson
-  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
   - buffer
   - jlexer
@@ -109,9 +107,11 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/api
-  version: 6c6dac0277229b9e9578c5ca3f74a4345d35cdc2
+  version: 11147472b7c934c474a2c484af3c0c5210b7a3af
   subpackages:
   - admissionregistration/v1alpha1
+  - admissionregistration/v1beta1
+  - apps/v1
   - apps/v1beta1
   - apps/v1beta2
   - authentication/v1
@@ -125,6 +125,7 @@ imports:
   - batch/v2alpha1
   - certificates/v1beta1
   - core/v1
+  - events/v1beta1
   - extensions/v1beta1
   - imagepolicy/v1alpha1
   - networking/v1
@@ -135,10 +136,12 @@ imports:
   - scheduling/v1alpha1
   - settings/v1alpha1
   - storage/v1
+  - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 180eddb345a5be3a157cea1c624700ad5bd27b8f
+  version: 019ae5ada31de202164b118aee88ee2d14075c31
   subpackages:
+  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
@@ -147,6 +150,7 @@ imports:
   - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
+  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/runtime
@@ -160,6 +164,7 @@ imports:
   - pkg/selection
   - pkg/types
   - pkg/util/clock
+  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
@@ -175,12 +180,14 @@ imports:
   - pkg/watch
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: 2ae454230481a7cb5544325e12ad7658ecccd19b
+  version: 78700dec6369ba22221b72770783300f143df150
   subpackages:
   - discovery
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
+  - kubernetes/typed/admissionregistration/v1beta1
+  - kubernetes/typed/apps/v1
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/apps/v1beta2
   - kubernetes/typed/authentication/v1
@@ -194,6 +201,7 @@ imports:
   - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/core/v1
+  - kubernetes/typed/events/v1beta1
   - kubernetes/typed/extensions/v1beta1
   - kubernetes/typed/networking/v1
   - kubernetes/typed/policy/v1beta1
@@ -203,6 +211,7 @@ imports:
   - kubernetes/typed/scheduling/v1alpha1
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1alpha1
   - kubernetes/typed/storage/v1beta1
   - pkg/version
   - rest
@@ -215,7 +224,7 @@ imports:
   - util/flowcontrol
   - util/integer
 - name: k8s.io/kube-openapi
-  version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1
+  version: 868f2f29720b192240e18284659231b440f9cda5
   subpackages:
   - pkg/common
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: a488111e226d9a9d752f9b533b5cba022a0f0ebf497b5d39c6381e54cc1c707e
-updated: 2018-06-14T15:03:28.346074486+03:00
+updated: 2018-06-14T15:04:55.35064782+03:00
 imports:
 - name: github.com/davecgh/go-spew
   version: 87df7c60d5820d0f8ae11afede5aa52325c09717
@@ -18,9 +18,9 @@ imports:
 - name: github.com/go-openapi/jsonreference
   version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/spec
-  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
 - name: github.com/go-openapi/swag
-  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -29,7 +29,7 @@ imports:
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
-  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
   - proto
   - ptypes
@@ -50,6 +50,8 @@ imports:
   version: 787624de3eb7bd915c329cba748687a3b22666a6
   subpackages:
   - diskcache
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/json-iterator/go
   version: 36b14963da70d11297d313183d7e6388c8510e1e
 - name: github.com/juju/ratelimit
@@ -57,7 +59,7 @@ imports:
 - name: github.com/klauspost/cpuid
   version: ae7887de9fa5d2db4eaa8174a7eff2c1ac00f2da
 - name: github.com/mailru/easyjson
-  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
   subpackages:
   - buffer
   - jlexer
@@ -72,6 +74,8 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/cobra
+  version: 35136c09d8da66b901337c6e86fd8e88a1a255bd
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/stretchr/objx
@@ -139,9 +143,8 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 019ae5ada31de202164b118aee88ee2d14075c31
+  version: 180eddb345a5be3a157cea1c624700ad5bd27b8f
   subpackages:
-  - pkg/api/equality
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
@@ -150,7 +153,6 @@ imports:
   - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
-  - pkg/conversion/unstructured
   - pkg/fields
   - pkg/labels
   - pkg/runtime
@@ -164,7 +166,6 @@ imports:
   - pkg/selection
   - pkg/types
   - pkg/util/clock
-  - pkg/util/diff
   - pkg/util/errors
   - pkg/util/framer
   - pkg/util/intstr
@@ -224,7 +225,7 @@ imports:
   - util/flowcontrol
   - util/integer
 - name: k8s.io/kube-openapi
-  version: 868f2f29720b192240e18284659231b440f9cda5
+  version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1
   subpackages:
   - pkg/common
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
   subpackages:
   - mock
 - package: k8s.io/client-go
-  version: v5.0.1
+  version: v6.0.0
 testImport:
 - package: github.com/smartystreets/goconvey
   version: ^1.6.2

--- a/tools/nfdadm/cmd/delete.go
+++ b/tools/nfdadm/cmd/delete.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/node-feature-discovery/tools/nfdadm/common"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type DeleteCmdFlags struct {
+	kubeconfig string
+	namespace  string
+}
+
+var deleteCmdFlags = &DeleteCmdFlags{}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+
+	deleteCmd.Flags().StringVarP(&deleteCmdFlags.kubeconfig, "kubeconfig", "c", common.DefaultKubeconfig(), "Kubeconfig file to use for communicating with the API server")
+	deleteCmd.Flags().StringVarP(&deleteCmdFlags.namespace, "namespace", "n", "default", "Namespace where node-feature-discovery is deployed")
+}
+
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete NFD",
+	Long:  "Delete Node Feature Discovery from a Kubernetes cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		errors := false
+
+		// Read kubeconfig
+		config, err := clientcmd.BuildConfigFromFlags("", initCmdFlags.kubeconfig)
+		if err != nil {
+			glog.Exitf("failed to read kubeconfig: %v", err)
+		}
+
+		// Create the client interface
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			glog.Exitf("failed to create clientset: %v", err)
+		}
+
+		// Check that the given namespace is valid
+		_, err = clientset.CoreV1().Namespaces().Get(deleteCmdFlags.namespace, metav1.GetOptions{})
+		if err != nil {
+			glog.Exitf("Namespace '%v' not found", deleteCmdFlags.namespace)
+		}
+
+		// Try to delete DaemonSet object
+		foundDS, err := deleteDaemonSet(deleteCmdFlags.namespace, clientset)
+		if err != nil {
+			glog.Errorf("failed to delete DaemonSet: %v", err)
+			errors = true
+		}
+
+		// Try to delete Job object
+		foundJob, err := deleteJob(deleteCmdFlags.namespace, clientset)
+		if err != nil {
+			glog.Errorf("failed to delete Job: %v", err)
+			errors = true
+		}
+
+		if foundDS == false && foundJob == false {
+			glog.Errorf("failed to find workload (Job or DaemonSet)")
+			errors = true
+		}
+
+		// Remove RBAC objects
+		err = deleteRBAC(deleteCmdFlags.namespace, clientset)
+		if err != nil {
+			glog.Errorf("failed to delete RBAC objects: %v", err)
+			errors = true
+		}
+
+		if errors == true {
+			glog.Exitf("errors were encountered when deleting objects!")
+		} else {
+			glog.Info("node feature discovery successfully deleted")
+		}
+	},
+}
+
+func deleteDaemonSet(namespace string, clientset kubernetes.Interface) (bool, error) {
+	dsInterface := clientset.AppsV1().DaemonSets(namespace)
+
+	// Check if a DaemonSet object exists
+	if _, err := dsInterface.Get("node-feature-discovery", metav1.GetOptions{}); err != nil {
+		glog.Info("DaemonSet object for node feature discovery not found")
+		return false, nil
+	}
+
+	glog.Info("deleting DaemonSet object")
+	return true, dsInterface.Delete("node-feature-discovery", &metav1.DeleteOptions{})
+}
+
+func deleteJob(namespace string, clientset kubernetes.Interface) (bool, error) {
+	jobInterface := clientset.BatchV1().Jobs(namespace)
+
+	// Check if a DaemonSet object exists
+	if _, err := jobInterface.Get("node-feature-discovery", metav1.GetOptions{}); err != nil {
+		glog.Info("Job object for node feature discovery not found")
+		return false, nil
+	}
+
+	glog.Info("deleting Job object")
+	return true, jobInterface.Delete("node-feature-discovery", &metav1.DeleteOptions{})
+}
+
+func deleteRBAC(namespace string, clientset kubernetes.Interface) error {
+	var failures []string
+
+	glog.Info("deleting ClusterRoleBinding")
+	err := clientset.RbacV1().ClusterRoleBindings().Delete("node-feature-discovery", &metav1.DeleteOptions{})
+	if err != nil {
+		glog.Errorf("failed to delete ClusterRoleBinding: %v", err)
+		failures = append(failures, "ClusterRoleBinding")
+	}
+
+	glog.Info("deleting ClusterRole")
+	err = clientset.RbacV1().ClusterRoles().Delete("node-feature-discovery", &metav1.DeleteOptions{})
+	if err != nil {
+		glog.Errorf("failed to delete ClusterRole: %v", err)
+		failures = append(failures, "ClusterRole")
+	}
+
+	glog.Info("deleting ServiceAccount")
+	err = clientset.CoreV1().ServiceAccounts(namespace).Delete("node-feature-discovery", &metav1.DeleteOptions{})
+	if err != nil {
+		glog.Errorf("failed to delete ServiceAccount: %v", err)
+		failures = append(failures, "ServiceAccount")
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("unable to delete some objects %v", failures)
+	}
+	return nil
+}

--- a/tools/nfdadm/cmd/init.go
+++ b/tools/nfdadm/cmd/init.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"os/user"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type InitCmdFlags struct {
+	image      string
+	kubeconfig string
+}
+
+var initCmdFlags = &InitCmdFlags{}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+
+	initCmd.Flags().StringVarP(&initCmdFlags.image, "image", "i", "quay.io/kubernetes_incubator/node-feature-discovery:v0.1.0", "Image to use for the node-feature-discovery binary")
+	initCmd.Flags().StringVarP(&initCmdFlags.kubeconfig, "kubeconfig", "c", defaultKubeconfig(), "Kubeconfig file to use for communicating with the API server")
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize NFD",
+	Long:  "Initialize Node Feature Discovery on a Kubernetes cluster",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Read kubeconfig
+		config, err := clientcmd.BuildConfigFromFlags("", initCmdFlags.kubeconfig)
+		if err != nil {
+			glog.Exitf("failed to read kubeconfig: %v", err)
+		}
+
+		// Create the client interface
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			glog.Exitf("failed to create clientset: %v", err)
+		}
+
+		// Configure DaemonSet
+		glog.Info("creating DaemonSet object for Node Feature Discovery")
+		_, err = createDaemonSet(initCmdFlags, clientset)
+		if err != nil {
+			glog.Exitf("failed to create DaemonSet: %v", err)
+		}
+	},
+}
+
+func createDaemonSet(flags *InitCmdFlags, clientset kubernetes.Interface) (*appsv1.DaemonSet, error) {
+
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-feature-discovery",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "node-feature-discovery",
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "node-feature-discovery",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "node-feature-discovery",
+					},
+				},
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name: "host-sys",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/sys",
+								},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "node-feature-discovery",
+							Image: flags.image,
+							Args:  []string{"--sleep-interval=60s"},
+							Env: []v1.EnvVar{
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      "host-sys",
+									ReadOnly:  true,
+									MountPath: "/host-sys",
+								},
+							},
+						},
+					},
+					HostNetwork: true,
+				},
+			},
+		},
+	}
+
+	return clientset.AppsV1().DaemonSets("default").Create(ds)
+}
+
+func defaultKubeconfig() string {
+	usr, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(usr.HomeDir, ".kube", "config")
+}

--- a/tools/nfdadm/cmd/init.go
+++ b/tools/nfdadm/cmd/init.go
@@ -17,10 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"os/user"
-	"path/filepath"
-
 	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/node-feature-discovery/tools/nfdadm/common"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -45,7 +43,7 @@ func init() {
 
 	initCmd.Flags().StringVarP(&initCmdFlags.image, "image", "i", "quay.io/kubernetes_incubator/node-feature-discovery:v0.1.0", "Image to use for the node-feature-discovery binary")
 	initCmd.Flags().BoolVarP(&initCmdFlags.job, "job", "j", false, "Deploy node feature discovery as a one-shot Job, instead of DaemonSet")
-	initCmd.Flags().StringVarP(&initCmdFlags.kubeconfig, "kubeconfig", "c", defaultKubeconfig(), "Kubeconfig file to use for communicating with the API server")
+	initCmd.Flags().StringVarP(&initCmdFlags.kubeconfig, "kubeconfig", "c", common.DefaultKubeconfig(), "Kubeconfig file to use for communicating with the API server")
 	initCmd.Flags().StringVarP(&initCmdFlags.namespace, "namespace", "n", "default", "Namespace where node-feature-discovery is created")
 }
 
@@ -324,12 +322,4 @@ func getAvailableNodes(clientset kubernetes.Interface) (int32, error) {
 	}
 
 	return readyNodes, nil
-}
-
-func defaultKubeconfig() string {
-	usr, err := user.Current()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(usr.HomeDir, ".kube", "config")
 }

--- a/tools/nfdadm/cmd/root.go
+++ b/tools/nfdadm/cmd/root.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "nfdadm",
+	Short: "nfdadm is a management tool for Kubernetes Node Feature Discovery",
+	Long:  "nfdadm is a helper tool for easier deployment and configuration of the Node Feature Discovery component of Kubernetes",
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/tools/nfdadm/cmd/root.go
+++ b/tools/nfdadm/cmd/root.go
@@ -17,10 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var rootCmd = &cobra.Command{
@@ -30,6 +32,13 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	// Add flags from glog
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	rootCmd.PersistentFlags().AddFlagSet(pflag.CommandLine)
+
+	// Print all logs to stderr, too
+	flag.Set("alsologtostderr", "true")
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/tools/nfdadm/cmd/version.go
+++ b/tools/nfdadm/cmd/version.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-incubator/node-feature-discovery/version"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCommand)
+}
+
+var versionCommand = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Long:  "Print version information of the nfdadm tool to stdout",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version.Get())
+	},
+}

--- a/tools/nfdadm/common/common.go
+++ b/tools/nfdadm/common/common.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"os/user"
+	"path/filepath"
+)
+
+func DefaultKubeconfig() string {
+	usr, err := user.Current()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(usr.HomeDir, ".kube", "config")
+}

--- a/tools/nfdadm/main.go
+++ b/tools/nfdadm/main.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/kubernetes-incubator/node-feature-discovery/tools/nfdadm/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Must not be const, supposed to be set using ldflags at build time
+var version = "undefined"
+
+func Get() string {
+	return version
+}


### PR DESCRIPTION
Implement a helper tool for deploying NFD (see issue #125). The script is currently cabable of deploying NFD as a DaemonSet or Job, configuring RBAC, creating target namespace and also undeploying NFD.