### PR TITLE
label-nodes.sh: match Ready without side-strings (#151)

### DIFF
--- a/label-nodes.sh
+++ b/label-nodes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Get the number of nodes in Ready state in the Kubernetes cluster
-NumNodes=$(kubectl get nodes | grep -i ready | wc -l)
+NumNodes=$(kubectl get nodes | grep -i ' ready ' | wc -l)
 
 # We set the .spec.completions and .spec.parallelism to the node count
 # We request a specific hostPort in the job spec to limit the number of pods


### PR DESCRIPTION
Counting nodes in Ready state was too fragile, matching
entries like:
Ready,SchedulingDisabled
NotReady
By requiring whitespace on both side, we accept only clean Ready.