### PR TITLE
Mention volume mounts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ node-feature-discovery.
                               value implies no re-labeling (i.e. infinite
                               sleep). [Default: 60s]
 ```
+**NOTE** Some feature sources need certain directories and/or files from the
+host mounted inside the NFD container. Thus, you need to provide Docker with the
+correct `--volume` options in order for them to work correctly when run
+stand-alone directly with `docker run`. See the
+[template spec](https://github.com/kubernetes-incubator/node-feature-discovery/blob/master/node-feature-discovery-daemonset.json.template)
+for up-to-date information about the required volume mounts.
 
 ## Feature discovery
 


### PR DESCRIPTION
Add a note about required volume mounts when running NFD directly with
docker run.