### PR TITLE
Configurable image build tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 .PHONY: all
 
+IMAGE_BUILD_CMD := docker build
+
 QUAY_DOMAIN_NAME := quay.io
 QUAY_REGISTRY_USER := kubernetes_incubator
 DOCKER_IMAGE_NAME := node-feature-discovery
 
 VERSION := $(shell git describe --tags --dirty --always)
 
-all: docker
+all: image
 
 # To override QUAY_REGISTRY_USER use the -e option as follows:
 # QUAY_REGISTRY_USER=<my-username> make docker -e.
-docker:
-	docker build --build-arg NFD_VERSION=$(VERSION) \
+image:
+	$(IMAGE_BUILD_CMD) --build-arg NFD_VERSION=$(VERSION) \
 		--build-arg http_proxy=$(http_proxy) \
 		--build-arg HTTP_PROXY=$(HTTP_PROXY) \
 		--build-arg https_proxy=$(https_proxy) \

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Download the source code.
 git clone https://github.com/kubernetes-incubator/node-feature-discovery
 ```
 
-**Build the Docker image:**
+**Build the container image:**
 
 ```
 cd <project-root>
@@ -233,9 +233,14 @@ make
 
 **NOTE: Our default docker image is hosted in quay.io. To override the 
 `QUAY_REGISTRY_USER` use the `-e` option as follows: 
-`QUAY_REGISTRY_USER=<my-username> make docker -e`**
+`QUAY_REGISTRY_USER=<my-username> make image -e`**
 
-Push the Docker Image (optional)
+You can also specify a build tool different from Docker, for example:
+```
+make IMAGE_BUILD_CMD="buildah bud"
+```
+
+Push the container image (optional, this example with Docker)
 
 ```
 docker push <quay-domain-name>/<registry-user>/<image-name>:<version>


### PR DESCRIPTION
Make it possible to specify an image build tool other than docker - a
limitation is that the build tool must be compatible with docker files,
of course. This makes it possible to build an NFD image without the
Docker daemon, for example.

The image build command is specified in a makefile variable and can be
overridden from command line, for example:
$ make IMAGE_BUILD_CMD="buildah bud"